### PR TITLE
Hotfix 1.0.2

### DIFF
--- a/SofaGW/__init__.py
+++ b/SofaGW/__init__.py
@@ -2,4 +2,4 @@ import SofaGW.utils as utils
 from SofaGW.simulation.SimServer import SimController
 
 __all__ = ["utils", 'SimController']
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/SofaGW/simulation/SimClient.py
+++ b/SofaGW/simulation/SimClient.py
@@ -65,7 +65,9 @@ class SimManager():
             self.sofa.action(translation=translation, rotation=rotation)
         elif order == 'step':
             realtime = self.orderdict['info'].get('realtime', True)
-            self.sofa.step(realtime=realtime)
+            errclose = self.sofa.step(realtime=realtime)
+            self.response['data'] = {'errclose': errclose}
+            close = errclose
         elif order == 'GetImage':
             image = self.sofa.GetImage()
             filename = self.commu_dir + f'/image_{time.time()}.pkl'

--- a/SofaGW/simulation/SimServer.py
+++ b/SofaGW/simulation/SimServer.py
@@ -141,6 +141,8 @@ class SimController():
         # Run the client.
         self.server.runclient(vessel_filename=vessel_filename)
     def action(self, translation=0, rotation=0):
+        translation = float(translation)
+        rotation = float(rotation)
         orderdict = {'order':'action',
                     'info': {'translation':translation,
                             'rotation':rotation}}

--- a/SofaGW/simulation/SimServer.py
+++ b/SofaGW/simulation/SimServer.py
@@ -142,8 +142,8 @@ class SimController():
         self.server.runclient(vessel_filename=vessel_filename)
     def action(self, translation=0, rotation=0):
         orderdict = {'order':'action',
-                    'info': {'translation':1,
-                            'rotation':0.1}}
+                    'info': {'translation':translation,
+                            'rotation':rotation}}
         self.exchange(orderdict)
     def step(self, realtime=False):
         orderdict = {'order': 'step',

--- a/SofaGW/simulation/scene.py
+++ b/SofaGW/simulation/scene.py
@@ -251,11 +251,11 @@ class SOFA():
 
 
     def action(self, translation=0, rotation=0):
-        self.root.InstrumentCombined.m_ircontroller.findData('xtip').value =\
-            self.root.InstrumentCombined.m_ircontroller.findData('xtip').value \
+        self.root.InstrumentCombined.m_ircontroller.findData('xtip').value \
+            = self.root.InstrumentCombined.m_ircontroller.findData('xtip').value \
             + np.array([0,translation,0], dtype=float)
-        self.root.InstrumentCombined.m_ircontroller.findData('rotationInstrument').value =\
-            self.root.InstrumentCombined.m_ircontroller.findData('rotationInstrument').value \
+        self.root.InstrumentCombined.m_ircontroller.findData('rotationInstrument').value \
+            = self.root.InstrumentCombined.m_ircontroller.findData('rotationInstrument').value \
             + np.array([0,rotation,0], dtype=float)
         
 

--- a/SofaGW/simulation/scene.py
+++ b/SofaGW/simulation/scene.py
@@ -15,6 +15,7 @@ import OpenGL.GLU
 # For using SOFA.
 class SOFA():
     def __init__(self, vessel_filename):
+        self.xtip_max = 800
         self.display_size = (640, 480)
         self.vessel_filename = vessel_filename
         self.start_scene()
@@ -219,15 +220,24 @@ class SOFA():
         
     def step(self, realtime=True):
         """Calculate simulator one step.
+        return
+            errclose(bool): If the simulation is closing because of some issue.
         """
-        target_time = time.time() + self.root.dt.value
-        Sofa.Simulation.animate(self.root, self.root.dt.value)
-        Sofa.Simulation.updateVisual(self.root)
-        if realtime:
-            current_time = time.time()
-            if target_time - current_time > 0:
-                time.sleep(target_time - current_time)
-        self.simple_render()
+        # Check 
+        xtip = self.root.InstrumentCombined.m_ircontroller.findData('xtip').value[1]
+        if xtip >= self.xtip_max:
+            errclose = True
+        else:
+            target_time = time.time() + self.root.dt.value
+            Sofa.Simulation.animate(self.root, self.root.dt.value)
+            Sofa.Simulation.updateVisual(self.root)
+            if realtime:
+                current_time = time.time()
+                if target_time - current_time > 0:
+                    time.sleep(target_time - current_time)
+            self.simple_render()
+            errclose = False
+        return errclose
 
     def simple_render(self):
         """Render camera of root onto pygame.

--- a/SofaGW/simulation/scene.py
+++ b/SofaGW/simulation/scene.py
@@ -136,7 +136,7 @@ class SOFA():
         VisuCatheter.addObject('Edge2QuadTopologicalMapping', nbPointsOnEachCircle=10, radius=2, input='@../../topoLines_cath/meshLinesCath', output='@ContainerCath', flipNormals=True)
         VisuCatheter.addObject('AdaptiveBeamMapping', name='VisuMapCath', useCurvAbs=True, printLog=False, interpolation='@../InterpolCatheter', input='@../DOFs', output='@Quads', isMechanical=False)
         VisuCatheterOgl = VisuCatheter.addChild('VisuOgl', activated=True)
-        VisuCatheterOgl.addObject('OglModel', name='Visual', color=[0.7, 0.7, 0.7], quads='@../ContainerCath.quads', material='texture Ambient 1 0.2 0.2 0.2 0.0 Diffuse 1 1.0 1.0 1.0 1.0 Specular 1 1.0 1.0 1.0 1.0 Emissive 0 0.15 0.05 0.05 0.0 Shininess 1 20')
+        VisuCatheterOgl.addObject('OglModel', name='Visual', color=[0.7, 0.7, 0.7, 0.9], quads='@../ContainerCath.quads', material='texture Ambient 1 0.2 0.2 0.2 0.0 Diffuse 1 1.0 1.0 1.0 1.0 Specular 1 1.0 1.0 1.0 1.0 Emissive 0 0.15 0.05 0.05 0.0 Shininess 1 20')
         VisuCatheterOgl.addObject('IdentityMapping', input='@../Quads', output='@Visual')
         ## Visualize guidewire
         VisuGuide = InstrumentCombined.addChild('VisuGuide', activated=True)
@@ -147,7 +147,7 @@ class SOFA():
         VisuGuide.addObject('Edge2QuadTopologicalMapping', nbPointsOnEachCircle=10, radius=1, input='@../../topoLines_guide/meshLinesGuide', output='@ContainerGuide', flipNormals=True, listening=True)
         VisuGuide.addObject('AdaptiveBeamMapping', name='visuMapGuide', useCurvAbs=True, printLog=False, interpolation='@../InterpolGuide', input='@../DOFs', output='@Quads', isMechanical=False)
         VisuGuideOgl = VisuGuide.addChild('VisuOgl')
-        VisuGuideOgl.addObject('OglModel', name='Visual', color=[0.2, 0.2, 0.8], material='texture Ambient 1 0.2 0.2 0.2 0.0 Diffuse 1 1.0 1.0 1.0 1.0 Specular 1 1.0 1.0 1.0 1.0 Emissive 0 0.15 0.05 0.05 0.0 Shininess 1 20', quads='@../ContainerGuide.quads')
+        VisuGuideOgl.addObject('OglModel', name='Visual', color=[0.2, 0.2, 0.8, 0.9], material='texture Ambient 1 0.2 0.2 0.2 0.0 Diffuse 1 1.0 1.0 1.0 1.0 Specular 1 1.0 1.0 1.0 1.0 Emissive 0 0.15 0.05 0.05 0.0 Shininess 1 20', quads='@../ContainerGuide.quads')
         VisuGuideOgl.addObject('IdentityMapping', input='@../Quads', output='@Visual')
         ## Visualize coils
         VisuCoils = InstrumentCombined.addChild('VisuCoils', activated=True)
@@ -158,7 +158,7 @@ class SOFA():
         VisuCoils.addObject('Edge2QuadTopologicalMapping', nbPointsOnEachCircle=10, radius=0.3, input='@../../topoLines_coils/meshLinesCoils', output='@ContainerCoils', flipNormals=True, listening=True)
         VisuCoils.addObject('AdaptiveBeamMapping', name='visuMapCoils', useCurvAbs=True, printLog=False, interpolation='@../InterpolCoils', input='@../DOFs', output='@Quads', isMechanical=False)
         VisuCoilsOgl = VisuCoils.addChild('VisuOgl')
-        VisuCoilsOgl.addObject('OglModel', name='Visual', color=[0.2, 0.8, 0.2], material='texture Ambient 1 0.2 0.2 0.2 0.0 Diffuse 1 1.0 1.0 1.0 1.0 Specular 1 1.0 1.0 1.0 1.0 Emissive 0 0.15 0.05 0.05 0.0 Shininess 1 20', quads='@../ContainerCoils.quads')
+        VisuCoilsOgl.addObject('OglModel', name='Visual', color=[0.2, 0.8, 0.2, 0.9], material='texture Ambient 1 0.2 0.2 0.2 0.0 Diffuse 1 1.0 1.0 1.0 1.0 Specular 1 1.0 1.0 1.0 1.0 Emissive 0 0.15 0.05 0.05 0.0 Shininess 1 20', quads='@../ContainerCoils.quads')
         VisuCoilsOgl.addObject('IdentityMapping', input='@../Quads', output='@Visual')
         
 

--- a/SofaGW/simulation/scene.py
+++ b/SofaGW/simulation/scene.py
@@ -186,7 +186,7 @@ class SOFA():
 
         
         # Set camera.
-        source = [-600,0,300]
+        source = [-600,50,300]
         lookAt = source+np.array([1,0,0])
         orientation = [ 0, -0.70710678, 0, 0.70710678]
         self.root.addObject("LightManager")

--- a/example_basic.py
+++ b/example_basic.py
@@ -3,11 +3,14 @@ from SofaGW.utils import SaveImage
 
 sim = SimController(timeout=10,
                     vessel_filename='vessel/phantom.obj')
-for i in range(500):
-    if i == 1:
-        sim.reset()
+
+errclose = False
+for i in range(2000):
     sim.action(translation=1, rotation=0.1)
-    sim.step(realtime=False)
+    errclose = sim.step(realtime=False)
+    print("errclose",errclose)
+    if errclose:
+        sim.reset()
     image = sim.GetImage()
     SaveImage(image=image, filename=f'image/image_{i}.jpg')
 sim.close()

--- a/example_checklimit.py
+++ b/example_checklimit.py
@@ -1,0 +1,12 @@
+from SofaGW.utils import SaveImage
+from SofaGW.simulation.scene import SOFA
+
+sim = SOFA(vessel_filename='vessel/phantom.obj')
+for i in range(2000):
+    print("i",i)
+    print("sim.root.InstrumentCombined.m_ircontroller.findData('xtip').value",sim.root.InstrumentCombined.m_ircontroller.findData('xtip').value)
+    print("sim.root.InstrumentCombined.m_ircontroller.findData('rotationInstrument').value",sim.root.InstrumentCombined.m_ircontroller.findData('rotationInstrument').value)
+    sim.action(translation=1, rotation=0.1)
+    sim.step(realtime=False)
+    image = sim.GetImage()
+    SaveImage(image=image, filename=f'image/image_{i}.jpg')

--- a/example_module.py
+++ b/example_module.py
@@ -3,11 +3,14 @@ from SofaGW.utils import SaveImage
 
 sim = SimController(timeout=10,
                     vessel_filename='vessel/phantom.obj')
-for i in range(500):
-    if i == 1:
-        sim.reset()
+
+errclose = False
+for i in range(2000):
     sim.action(translation=1, rotation=0.1)
-    sim.step(realtime=False)
+    errclose = sim.step(realtime=False)
+    print("errclose",errclose)
+    if errclose:
+        sim.reset()
     image = sim.GetImage()
     SaveImage(image=image, filename=f'image/image_{i}.jpg')
 sim.close()


### PR DESCRIPTION


#### 1. (Mandatory) Add transparancy to cath,GW,coil in SofaGW. (To get the vessel map)
#### 2. Relocate the source of the camera in SofaGW same as sofagym.
#### 3. (Mandatory) Fix info in SofaGW.SimController.action to use given translation, rotation.
#### 4. Fix the phenomenon in SofaGW so that if SOFA is closed because of some error, reset the simulation and the episode.
For this error:
```
########## SIG 11 - SIGSEGV: segfault ##########
sofa::helper::BackTrace::sig(int)
sofa::component::controller::interventionalradiologycontroller::InterventionalRadiologyController<sofa::defaulttype::StdRigidTypes<3u, double> >::applyInterventionalRadiologyController()
sofa::component::controller::interventionalradiologycontroller::InterventionalRadiologyController<sofa::defaulttype::StdRigidTypes<3u, double> >::onBeginAnimationStep(double)
sofa::simulation::PropagateEventVisitor::processNodeTopDown(sofa::simulation::Node*)
sofa::simulation::graph::DAGNode::executeVisitorTopDown(sofa::simulation::Visitor*, std::__cxx11::list<sofa::simulation::graph::DAGNode*, std::allocator[sofa::simulation::graph::DAGNode*](https://github.com/candi4/SofaGuidewireNav/compare/hotfix-1.0.2?expand=1) >&, std::map<sofa::simulation::graph::DAGNode*, sofa::simulation::graph::DAGNode::StatusStruct, std::less[sofa::simulation::graph::DAGNode*](https://github.com/candi4/SofaGuidewireNav/compare/hotfix-1.0.2?expand=1), std::allocator<std::pair<sofa::simulation::graph::DAGNode* const, sofa::simulation::graph::DAGNode::StatusStruct> > >&, sofa::simulation::graph::DAGNode*)
sofa::simulation::graph::DAGNode::executeVisitorTopDown(sofa::simulation::Visitor*, std::__cxx11::list<sofa::simulation::graph::DAGNode*, std::allocator[sofa::simulation::graph::DAGNode*](https://github.com/candi4/SofaGuidewireNav/compare/hotfix-1.0.2?expand=1) >&, std::map<sofa::simulation::graph::DAGNode*, sofa::simulation::graph::DAGNode::StatusStruct, std::less[sofa::simulation::graph::DAGNode*](https://github.com/candi4/SofaGuidewireNav/compare/hotfix-1.0.2?expand=1), std::allocator<std::pair<sofa::simulation::graph::DAGNode* const, sofa::simulation::graph::DAGNode::StatusStruct> > >&, sofa::simulation::graph::DAGNode*)
sofa::simulation::graph::DAGNode::doExecuteVisitor(sofa::simulation::Visitor*, bool)
sofa::component::animationloop::FreeMotionAnimationLoop::step(sofa::core::ExecParams const*, double)
sofa::simulation::Simulation::animate(sofa::simulation::Node*, double)
PyCFunction_Call
_PyObject_MakeTpCall
_PyEval_EvalFrameDefault
_PyEval_EvalCodeWithName
_PyEval_EvalFrameDefault
_PyEval_EvalCodeWithName
PyEval_EvalCodeEx
PyEval_EvalCode
PyRun_SimpleFileExFlags
Py_BytesMain
__libc_start_main
Segmentation fault (core dumped)
```